### PR TITLE
feat(hook): add no-ephemeral-link

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,3 +21,8 @@
     always_run: true
     pass_filenames: false
     stages: [push]
+-   id: no-ephemeral-links
+    name: No ephemeral links
+    language: script
+    entry: ./no-ephemeral-links.sh
+    stages: [commit]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ It's a pre-push hook and will always run
 #### `check-commit-first-line-length`
 Check that the first line of commit message is less than 72 characters
 It's a pre-push hook and will always run
+
+#### `no-ephemeral-links`
+Time is fleeting, we change services.
+Consequently to keep the code futureproof we don't
+want links to ephemeral thrid party stuff (slack, clubhouse, atlassian)

--- a/no-ephemeral-links.sh
+++ b/no-ephemeral-links.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+exit_status=0
+
+for i
+do
+  grep "$i" -e "://kpler.slack.com" -e "://kpler1.atlassian.net/browse" -e "://app.clubhouse.io/kplertechnology" --with-filename --line-number | awk '{print "- "$1}'
+  if [ ${PIPESTATUS[0]} -eq 0 ]
+  then
+    exit_status=1
+  fi
+done
+exit ${exit_status}


### PR DESCRIPTION
Add `no-ephemeral-links` hook.
For the first version we ban links to:
  - kpler.slack.com
  - kpler1.atlassian.net
  - app.clubhouse.io/kplertechnology

In a future version we may want to ban also links to:
  - old kpler clubhouse (e.g. freight)
  - kpler trello
   
Ex:
```
 > pre-commit try-repo ../kp-pre-commit-hooks no-ephemeral-links --files etl/tests/test_vessel.py
No ephemeral links.......................................................Failed
- hook id: no-ephemeral-links
- exit code: 1

- etl/tests/test_vessel.py:197:
```

```
> pre-commit try-repo ../kp-pre-commit-hooks no-ephemeral-links --files README.md 
No ephemeral links.......................................................Passed
```
