### PR TITLE
feat(git-branch-linearity): add a disclaimer

### DIFF
--- a/git-branch-linearity.sh
+++ b/git-branch-linearity.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
-out=$(git log origin/master..HEAD --merges)
+out=$(git log origin/master..HEAD --merges --oneline)
 
 exit_status=$?
 if [ -n  "$out" ]
 then
-    echo "Please rebase your branch, merge commit(s):" >&2
+    echo "Please rebase your branch" >&2
+    echo "If your branch or its base branch is a release branch then ignore this error" >&2
+    echo "\nMerge commit(s):" >&2
     echo "$out" >&2
+    # Disclaimer: current version of the check doesn't work well with release branches
 exit_status=1
 fi
 


### PR DESCRIPTION
As `git-branch-linearity` is misleading when a release branch is involved.
I've added a disclaimer to prevent people from loosing time trying to fix a false positive error.

A better solution would be to find a way to change the check base:
  - on the base branch (Would require: [CCI-I-894](https://ideas.circleci.com/cloud-feature-requests/p/provide-env-variable-for-branch-name-targeted-by-pull-request))
  - on the branch name _(would require a strict naming convention for release branches)_
  
 Output:
 ```
Please rebase your branch
If your branch or its base branch is a release branch then ignore this error

Merge commit(s):
c486b3427 (origin/v15-release) Merge pull request #2995 from Kpler/fix/search/product-and-vessel-typeahaead
f8c812d13 Merge pull request #2979 from Kpler/lng-unit
b95a00643 Merge pull request #2957 from Kpler/lng-tooltip-capa
```