### PR TITLE
feat(git-branch-linearity): add target-branch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ Some out-of-the-box hooks for [pre-commit](https://github.com/pre-commit/pre-com
 Add this to your `.pre-commit-config.yaml`
 
     -   repo: https://github.com/Kpler/kp-pre-commit-hooks.git
-        rev: v0.0.3  # Use the ref you want to point at
+        rev: v0.0.7  # Use the ref you want to point at
         hooks:
         -   id: check-branch-linearity
-        -   id: check-commit-first-line-length
         -   id: check-branch-name
+        -   id: no-ephemeral-links
+            exclude: '\.md$'
 
 ### Hooks available
 
 #### `check-branch-linearity`
-Simply check that your branch doesn't not contain any merge compare to master.
+Simply check that your branch doesn't not contain any merge compare to `master` or `main` branch.
 It's a pre-push hook and will always run
 
 #### `check-branch-name`

--- a/git-branch-linearity.sh
+++ b/git-branch-linearity.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
-out=$(git log origin/master..HEAD --merges --oneline)
+
+if [ "$(git branch --list main)" ]; then TARGET_BRANCH="main"; else TARGET_BRANCH="master"; fi
+
+echo "Target branch: $TARGET_BRANCH"
+out=$(git log origin/${TARGET_BRANCH}..HEAD --merges --oneline)
 
 exit_status=$?
 if [ -n  "$out" ]


### PR DESCRIPTION
Some of our git repositories use `main` as "master" branch like on `datascience-models`

With hard-coded target branch name, the hook will fail on project without `master` branch.

Default target branch was not touched and stay `master`.

If your project need an other target branch name, specify on the pre-commit hook config .yaml file. 
Bellow, an example:

```
  - repo: https://github.com/Kpler/kp-pre-commit-hooks
    rev: v0.0.7
    hooks:
      - id: check-branch-linearity
        args: [--target-branch=main]
```