### PR TITLE
fix: configure target branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Some out-of-the-box hooks for [pre-commit](https://github.com/pre-commit/pre-com
 
 Add this to your `.pre-commit-config.yaml`
 
+```yaml
     -   repo: https://github.com/Kpler/kp-pre-commit-hooks.git
         rev: v0.0.7  # Use the ref you want to point at
         hooks:
@@ -14,12 +15,20 @@ Add this to your `.pre-commit-config.yaml`
         -   id: check-branch-name
         -   id: no-ephemeral-links
             exclude: '\.md$'
+```
 
 ### Hooks available
 
 #### `check-branch-linearity`
-Simply check that your branch doesn't not contain any merge compare to `master` or `main` branch.
+Simply check that your branch doesn't not contain any merge compare to a target branch, `master` by default.
 It's a pre-push hook and will always run
+
+To configure the target branch:
+```yaml
+    hooks:
+    -   id: check-branch-linearity
+        args: [targetbranch]
+```
 
 #### `check-branch-name`
 Check that branch name is less than 70 characters

--- a/git-branch-linearity.sh
+++ b/git-branch-linearity.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-git fetch origin main:refs/remotes/origin/main 2> /dev/null
-if [ $? -eq 0 ]; then TARGET_BRANCH="main"; else TARGET_BRANCH="master"; fi
+# Use parameter passed to the script or default to master
+TARGET_BRANCH="${1:-master}"
+
 echo "Target branch: $TARGET_BRANCH"
+git fetch origin $TARGET_BRANCH 2> /dev/null
 
 out=$(git log origin/${TARGET_BRANCH}..HEAD --merges --oneline)
 exit_status=$?


### PR DESCRIPTION
Add the ability to configure the target branch to check against the linearity.

It works fine so far on CircleCI as in the checkout it pulls everything. But it doesn't work with Github actions where it only fetch the branch. Hence the `git fetch origin main` we had.

You'll need to add an `args: [main]` if you don't want to use `master`:
```yaml
- repo: https://github.com/Kpler/kp-pre-commit-hooks
  rev: v0.0.9
  hooks:
    - id: check-branch-linearity
      args: [main]

```