### PR TITLE
feat: add generic gh action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 pre-commit-hooks
 ================
 
-Some out-of-the-box hooks for [pre-commit](https://github.com/pre-commit/pre-commit).
+Some out-of-the-box hooks for [pre-commit](https://github.com/pre-commit/pre-commit), and
+a github action to easily run all kind of hooks from github CI.
 
 ### Using pre-commit-hooks with pre-commit
 
@@ -38,6 +39,27 @@ It's a pre-push hook and will always run
 Time is fleeting, we change services.
 Consequently to keep the code futureproof we don't
 want links to ephemeral thrid party stuff (slack, clubhouse, atlassian)
+
+### Github actions
+
+Run pre-commit hooks of type: commit, push and commit-msg
+
+Example:
+```yaml
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Kpler/kp-pre-commit-hooks@version
+      with:
+        skipped-hooks: 'no-commit-to-branch'
+        main-branch: 'master'
+```
+
+#### Alternatives:
+  - [The official pre-commit action](https://github.com/pre-commit/action): deprecated and hard to use with several type of hooks
+  - [The pre-commit CI](https://pre-commit.ci/): yet another CI and expensive (pricing per user)
 
 ### Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,44 @@
+name: 'Pre-commit'
+description: 'Run pre-commit hooks'
+inputs:
+  skipped-hooks:
+    description: 'Skip some hooks, eg "no-commit-to-branch,foo"'
+    required: true
+    default: ''
+  main-branch:
+    description: 'master or main'
+    required: true
+    default: 'main'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v2
+    - name: Skip some hooks
+      run: echo "SKIP=${{ inputs.skipped-hooks }}" >> $GITHUB_ENV
+      if: ${{ inputs.skipped-hooks }} != ''
+      shell: bash
+    - name: Install pre-commit
+      run: pip install pre-commit
+      shell: bash
+    - name: Cache pre-commit hooks
+      uses: actions/cache@v2
+      with:
+        path: '~/.cache/pre-commit'
+        key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+    - name: Run pre-commit
+      run: |
+            pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage commit
+            pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage push
+
+            # https://github.com/jorisroovers/gitlint/issues/148
+            git config --add user.email ''
+            git config --add user.name ''
+
+            git fetch origin ${{ inputs.main-branch }} 2> /dev/null
+            for commit in $(git rev-list origin/${{ inputs.main-branch }}..HEAD)
+            do
+               git show -s --pretty=format:%B $commit > tmp
+               pre-commit run --color=always --hook-stage commit-msg --commit-msg-filename tmp
+            done
+      shell: bash
+


### PR DESCRIPTION
Add a generic composite action to run pre-commit from the CI.

It's a replacement for https://github.com/pre-commit/action because:
   - it's a deprecated action
   - it restores the cache for each hook-stage
   - painful to use with hooks of type commit-msg


Note1: Might be better to put this action in its own repo.
Note2: The action is deprecated because they are pushing for their own CI (which cames with its own cons)

Ex of usage: https://github.com/Kpler/ct-webserver/pull/1894

![image](https://user-images.githubusercontent.com/8612474/143984175-e09b5901-aadb-4cfb-bbe1-6b14a3230d48.png)
