### PR TITLE
Allow dependabot branches on Kpler repositories

### DIFF
--- a/branch-naming.sh
+++ b/branch-naming.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 exit_status=0
-currentbranch=`git symbolic-ref --short HEAD`
-if [ $(expr length "$currentbranch") -gt 70 ]
+currentbranch=$(git symbolic-ref --short HEAD)
+dependabot="dependabot"
+# NOTE: Branches created by Dependabot does not have any limit, according to
+# https://github.com/dependabot/dependabot-core/issues/396, that's why we allow them
+if [ "$(expr length "$currentbranch")" -gt 70 ] && [[ ! "$currentbranch" =~ $dependabot ]]
 then
   exit_status=1
   echo "Branch name too long, should be less than 70 characters."


### PR DESCRIPTION
Allow branches created by `dependabot`
No setting exists for that yet: https://github.com/dependabot/dependabot-core/issues/396