### PR TITLE
fix: improve avro library detection

### DIFF
--- a/kafka/check-local-schemas.sh
+++ b/kafka/check-local-schemas.sh
@@ -116,6 +116,10 @@ run_schema_generator_code() {
   # to the existing source code, so we can run our generator code alongside the existing code
   # We need that as the generator code import the schema class
   sbt_command+="set Compile / unmanagedSourceDirectories += file(\"${generator_source_folder}\");"
+  # Dynamically add the required dependencies to the build.sbt file
+  sbt_command+="set libraryDependencies += \"com.lihaoyi\" %% \"upickle\" % \"3.1.3\";"
+  sbt_command+="set libraryDependencies += \"com.lihaoyi\" %% \"os-lib\" % \"0.9.1\";"
+
   sbt_command+="runMain kp_pre_commit_hooks.generateSchemaFile ${target_schema_file}"
 
   sbt -batch -error "${sbt_command}"


### PR DESCRIPTION
So far we checked for the presence of the library in the target schema
class file but this library could be loaded indirectly and not
explicitely listed.

As a fallback, we now:

 - look for the library string without the import keyword, to allow
   to specify it using the schemas static annotation if needed
   (for instance 'Schema(library="com.sksamuel.avro4s")')

 - search for the library in the build.sbt as well.