### PR TITLE
refactor: improve kafka-check-schemas commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Add this to your `.pre-commit-config.yaml`
         -   id: check-branch-name
         -   id: no-ephemeral-links
             exclude: '\.md$'
+        # [...] add other specific hook id relevant from your project
 ```
 
 ### Hooks available
@@ -41,7 +42,17 @@ Consequently to keep the code futureproof we don't
 want links to ephemeral thrid party stuff (slack, clubhouse, atlassian)
 
 #### `fastapi-generate-openapi-specification`
+
 Generate the Open API spec from a Fast API. If it has changed, write the new one and fails. If not, succeeds.
+
+#### `kafka-check-schemas`
+
+This hook is specific to Kafka Stream or Kafka Producers application and will check that the repositories contains AVRO schemas files, under the `schemas/` folder, that are consistent with the code.
+The presence of such schemas is required by the Kpler GitHub actions [check-kafka-schemas-compatibility] and [upload-kafka-schemas] and is also mandatory for Kafka application deployment in Kubernetes.
+
+[check-kafka-schemas-compatibility]: https://github.com/Kpler/github-actions/blob/main/actions/kafka/check-kafka-schemas-compatibility/README.md
+[upload-kafka-schemas]: https://github.com/Kpler/github-actions/blob/main/actions/kafka/upload-kafka-schemas/README.md
+
 
 ### Contributing
 


### PR DESCRIPTION
Creating this PR to open the discussion about how to improve the pre-commit hook for checking kafka schemas.

The current hooks works by calling a specific target in scala projects, `generateKafkaSchemas`, and checking if this leads to a schemas file different or not (which would mean the schemas is not properly updated)

This works but has some disadvantages:
 - the pre-commit run `sbt` which is slow to start so this slows down the pre-commit execution. This is mitigated by the fact that it only runs when the src/../models folder is updated but this is not entirely satisfying
 - when a schema is not up to date, it must even be run twice: one when pre-commit discovers that the schemas are not up to date and one when we have commited the updated files as the pre-commit will check again.

Basically, we want the schemas generation to be fast and not get in the way of the developers, but we also would like to detect and warn the devs if for some reason these schemas are not up to date anymore when they commit (either they forgot to commit the new schemas files or the schemas update mechanism doesn't work anymore).

One option that has been mentioned is to include that step in the compile stage so that no time in lost in multiple sbt executions. This means the schemas files would be refreshed at each compilation and we would need to find a way to check if the committed ones have been refreshed.









