### PR TITLE
chore: ignore merge commits to target branch at tip of history

### DIFF
--- a/git-branch-linearity.sh
+++ b/git-branch-linearity.sh
@@ -4,18 +4,28 @@
 TARGET_BRANCH="${1:-main}"
 
 echo "Target branch: $TARGET_BRANCH"
-git fetch origin $TARGET_BRANCH 2> /dev/null
+git fetch --no-tags --depth=1 origin $TARGET_BRANCH 2> /dev/null
+target_sha=$(git rev-parse origin/${TARGET_BRANCH})
 
-out=$(git log origin/${TARGET_BRANCH}..HEAD --merges --oneline)
+# If in a github PR, base from tip of branch, not the merge commit
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    git fetch --no-tags --shallow-exclude="$target_sha" origin "$GITHUB_HEAD_REF"  2> /dev/null
+    tip=$(git rev-parse origin/$GITHUB_HEAD_REF)
+else
+    tip="HEAD"
+fi
+
+out=$(git log ${target_sha}..${tip} --merges --oneline)
 exit_status=$?
+
 if [ -n  "$out" ]
 then
     echo "Please rebase your branch" >&2
     echo "If your branch or its base branch is a release branch then ignore this error" >&2
-    echo "\nMerge commit(s):" >&2
+    echo >&2
+    echo "Merge commit(s):" >&2
     echo "$out" >&2
     # Disclaimer: current version of the check doesn't work well with release branches
     exit_status=1
 fi
-
 exit ${exit_status}


### PR DESCRIPTION
Context: [Slack](https://kpler.slack.com/archives/CDQ3WC86B/p1710492088260229)

The `pull_request` target creates a (fake) merge commit that fails the branch linearity check.

This change tries to detect if the commit at the tip is a merge commit against the target branch.
If that is the case, then it ignores it.

Tried it a bit locally and appears to work, but no guarantees for it 😅

\+ a small change to make it nicer to use as a direct shell script