### PR TITLE
chore: allow merge queue branch names

### DIFF
--- a/branch-naming.sh
+++ b/branch-naming.sh
@@ -3,9 +3,10 @@
 exit_status=0
 currentbranch=$(git symbolic-ref --short HEAD)
 dependabot="dependabot"
+merge-queue="gh-readonly-queue"
 # NOTE: Branches created by Dependabot does not have any limit, according to
 # https://github.com/dependabot/dependabot-core/issues/396, that's why we allow them
-if [ "$(expr length "$currentbranch")" -gt 70 ] && [[ ! "$currentbranch" =~ $dependabot ]]
+if [ "$(expr length "$currentbranch")" -gt 70 ] && [[ ! "$currentbranch" =~ $dependabot ]] && [[ ! "$currentbranch" =~ merge-queue ]]
 then
   exit_status=1
   echo "Branch name too long, should be less than 70 characters."


### PR DESCRIPTION
When trying to setup merge queues in `ct-pipeline`, we found out that branch naming rule is failing sanity checks on merge queue branches: https://github.com/Kpler/ct-pipeline/actions/runs/15739391075

This PR exclude branches created for merge group, starting with `gh-readonly-queue`