### PR TITLE
fix: fix branch-naming.sh

### DIFF
--- a/branch-naming.sh
+++ b/branch-naming.sh
@@ -3,10 +3,10 @@
 exit_status=0
 currentbranch=$(git symbolic-ref --short HEAD)
 dependabot="dependabot"
-merge-queue="gh-readonly-queue"
+mergequeue="gh-readonly-queue"
 # NOTE: Branches created by Dependabot does not have any limit, according to
 # https://github.com/dependabot/dependabot-core/issues/396, that's why we allow them
-if [ "$(expr length "$currentbranch")" -gt 70 ] && [[ ! "$currentbranch" =~ $dependabot ]] && [[ ! "$currentbranch" =~ merge-queue ]]
+if [ "$(expr length "$currentbranch")" -gt 70 ] && [[ ! "$currentbranch" =~ $dependabot ]] && [[ ! "$currentbranch" =~ $mergequeue ]]
 then
   exit_status=1
   echo "Branch name too long, should be less than 70 characters."


### PR DESCRIPTION
Typo on branch-naming.sh script.
Tested now, it works.