### PR TITLE
feat: add zizmor-workflows hook for GitHub Actions audits

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,10 +14,10 @@ jobs:
   bump-version:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: '0'
-      - uses: anothrNick/github-tag-action@1.75.0
+      - uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -60,3 +60,21 @@
     always_run: true
     pass_filenames: false
     files: \.tfvars$
+
+-   id: zizmor-workflows
+    name: Audit GitHub Actions workflows with zizmor (offline)
+    language: python
+    entry: zizmor --offline
+    args: [--min-severity=high]
+    files: ^\.github/(workflows/.*\.ya?ml|actions/.*/action\.ya?ml)$
+    stages: [pre-commit]
+    additional_dependencies: [zizmor==1.24.1]
+
+-   id: zizmor-workflows-online
+    name: Audit GitHub Actions workflows with zizmor (online, requires GH_TOKEN)
+    language: python
+    entry: zizmor
+    args: [--min-severity=high]
+    files: ^\.github/(workflows/.*\.ya?ml|actions/.*/action\.ya?ml)$
+    stages: [manual]
+    additional_dependencies: [zizmor==1.24.1]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,54 @@ repos:
 [example of implementation]: https://github.com/Kpler/template-kafka-stream-msk/blob/main/src/ci/scala/schema_generator/VulcanSchemaGenerator.scala
 [sbt command]: https://github.com/Kpler/template-kafka-stream-msk/blob/main/build.sbt#L75
 
+#### `zizmor-workflows` / `zizmor-workflows-online`
+
+Audit GitHub Actions workflow and composite-action files with [zizmor] for common security issues
+(unpinned actions, dangerous triggers, excessive permissions, template injection, and ~30 others).
+
+Two variants are provided so the same tool can be used locally without credentials and in CI with
+the full audit set:
+
+| Hook | Stage | Runs |
+|------|-------|------|
+| `zizmor-workflows` | `pre-commit` (default) | Offline audits only. No network, no token. |
+| `zizmor-workflows-online` | `manual` (opt-in) | All audits, including `impostor-commit`, `known-vulnerable-actions`, `ref-confusion`, `stale-action-refs`. Requires `GH_TOKEN`. |
+
+Both hooks match `.github/workflows/*.y[a]ml` and `.github/actions/*/action.y[a]ml` and default to
+`--min-severity=high` (only `error[...]`-level findings block). Override via `args:` in your
+`.pre-commit-config.yaml` to surface more:
+
+```yaml
+- id: zizmor-workflows
+  args: [--min-severity=medium]  # or: low, informational
+```
+
+**Local usage** — add to `.pre-commit-config.yaml`:
+```yaml
+repos:
+  - repo: https://github.com/Kpler/kp-pre-commit-hooks.git
+    rev: v0.23.0  # Use the latest version
+    hooks:
+      - id: zizmor-workflows
+      # Also declare the online variant so CI can invoke it. Because its stage
+      # is `manual`, it will not fire on `git commit` / `git push` locally.
+      - id: zizmor-workflows-online
+```
+
+**CI usage** — add a step to your GitHub Actions workflow:
+```yaml
+- uses: actions/checkout@v4
+- uses: actions/setup-python@v5
+  with:
+    python-version: '3.11'
+- run: pip install pre-commit
+- run: pre-commit run --hook-stage manual --all-files zizmor-workflows-online
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+[zizmor]: https://docs.zizmor.sh/
+
 ### Contributing
 
 #### Debugging / testing


### PR DESCRIPTION
## Summary
- Adds two pre-commit hook variants (`zizmor-workflows`, `zizmor-workflows-online`) that audit GitHub Actions workflow and composite-action files with [zizmor](https://docs.zizmor.sh/). Offline variant runs on `pre-commit` stage (no token, no network); online variant runs on `manual` stage for CI (requires `GH_TOKEN`, adds 4 supply-chain audits).
- Both hooks default to `--min-severity=high` so only `error[...]`-level findings block commits. Consumers can loosen via `args:`.
- Zizmor pinned to `1.24.1`, installed via PyPI wheel so consumers need no host install.
- Fixes surfaced by running the new hook on this repo's own workflow: SHA-pins `actions/checkout@v6` and `anothrNick/github-tag-action@1.75.0` in `bump-version.yml`.

## Design notes
- `manual` stage for the online variant is the pre-commit-native idiom for "CI-only" hooks — keeps the online audits out of local runs where `GH_TOKEN` is usually absent, while making CI opt-in a one-liner (`pre-commit run --hook-stage manual --all-files zizmor-workflows-online`). No existing Kpler repo uses `manual` yet, so this also establishes the pattern.
- `--offline` lives in `entry:` (non-overridable) for the local variant; `--min-severity=high` lives in `args:` (overridable) so consumers can surface more findings when they want a stricter audit.
- Scope of files regex covers both `.github/workflows/*.y[a]ml` and `.github/actions/*/action.y[a]ml` (composite actions).

## Test plan
- [x] `pre-commit try-repo . zizmor-workflows --files .github/workflows/bump-version.yml` — passes on current tree (0 findings at `high` severity after SHA pinning).
- [x] Same command before the SHA fix — fails with two `error[unpinned-uses]` findings, confirming the hook detects the issue.
- [x] `pre-commit run --files .pre-commit-hooks.yaml README.md` — all baseline hooks pass on touched files.
- [ ] After merge and release tagging, try from a consumer repo via `pre-commit try-repo https://github.com/Kpler/kp-pre-commit-hooks --rev <new-tag> zizmor-workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)