### PR TITLE
fix: make git-branch-linearity.sh work with shallow CI clones

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  git-branch-linearity:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run git-branch-linearity tests
+        run: ./tests/test_git_branch_linearity.sh
+
+  # Runs the hook on itself in a real PR context (actions/checkout default
+  # shallow clone + GITHUB_HEAD_REF). This is the exact setup that broke in
+  # v0.57.0.
+  git-branch-linearity-self:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run hook against PR branch
+        run: ./git-branch-linearity.sh ${{ github.base_ref }}

--- a/git-branch-linearity.sh
+++ b/git-branch-linearity.sh
@@ -4,21 +4,30 @@
 TARGET_BRANCH="${1:-main}"
 
 echo "Target branch: $TARGET_BRANCH"
-git fetch --no-tags --depth=1 origin $TARGET_BRANCH 2> /dev/null
-target_sha=$(git rev-parse origin/${TARGET_BRANCH})
+git fetch --no-tags --depth=1 origin "$TARGET_BRANCH"
+target_sha=$(git rev-parse FETCH_HEAD)
 
-# If in a github PR, base from tip of branch, not the merge commit
+# If in a github PR, base from tip of branch, not the merge commit.
 if [ -n "$GITHUB_HEAD_REF" ]; then
-    git fetch --no-tags --shallow-exclude="$target_sha" origin "$GITHUB_HEAD_REF"  2> /dev/null
-    tip=$(git rev-parse origin/$GITHUB_HEAD_REF)
+    # --shallow-exclude requires a ref name (branch/tag), not a SHA: the value
+    # is forwarded to the server as `deepen-not <ref>` in protocol v2, which
+    # rejects commit ids.
+    if ! git fetch --no-tags --shallow-exclude="$TARGET_BRANCH" origin "$GITHUB_HEAD_REF"; then
+        # Fallback for remotes that do not honor shallow-exclude.
+        git fetch --no-tags origin "$GITHUB_HEAD_REF"
+    fi
+    # Read from FETCH_HEAD rather than origin/$GITHUB_HEAD_REF: the origin
+    # remote in a CI clone (actions/checkout, clone --depth=1) has a narrow
+    # refspec that does not map arbitrary branches into refs/remotes/origin/*.
+    tip=$(git rev-parse FETCH_HEAD)
 else
     tip="HEAD"
 fi
 
-out=$(git log ${target_sha}..${tip} --merges --oneline)
+out=$(git log "${target_sha}..${tip}" --merges --oneline)
 exit_status=$?
 
-if [ -n  "$out" ]
+if [ -n "$out" ]
 then
     echo "Please rebase your branch" >&2
     echo "If your branch or its base branch is a release branch then ignore this error" >&2

--- a/tests/test_git_branch_linearity.sh
+++ b/tests/test_git_branch_linearity.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# End-to-end tests for git-branch-linearity.sh.
+#
+# These tests exercise the hook in a realistic GitHub Actions PR environment:
+# a shallow clone (depth=1) with GITHUB_HEAD_REF set. This reproduces the
+# failure mode seen in practice when --shallow-exclude was given a SHA
+# instead of a ref name.
+
+set -eu -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../git-branch-linearity.sh"
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+pass=0
+fail=0
+
+on_exit() {
+    rc=$?
+    if [ -n "${WORKDIR:-}" ] && [ -d "${WORKDIR:-}" ]; then
+        rm -rf "$WORKDIR"
+    fi
+    if [ "$fail" -gt 0 ]; then
+        echo ""
+        echo "FAIL: $fail test(s) failed, $pass passed"
+        exit 1
+    fi
+    if [ "$rc" -ne 0 ]; then
+        exit "$rc"
+    fi
+    echo ""
+    echo "OK: $pass test(s) passed"
+}
+trap on_exit EXIT
+
+setup_origin_with_linear_branch() {
+    # Build an "origin" bare repo with:
+    #   - main at commit M1
+    #   - feature branched from M1, with one additional linear commit F1
+    WORKDIR=$(mktemp -d)
+    ORIGIN="$WORKDIR/origin.git"
+    UPSTREAM="$WORKDIR/upstream"
+
+    git init --bare -q -b main "$ORIGIN"
+    git init -q -b main "$UPSTREAM"
+    (
+        cd "$UPSTREAM"
+        git config user.email test@example.com
+        git config user.name test
+        git remote add origin "$ORIGIN"
+
+        echo initial > file.txt
+        git add file.txt
+        git -c commit.gpgsign=false commit -q -m "M1 initial"
+        git push -q origin main
+
+        git checkout -q -b feature/linear
+        echo change >> file.txt
+        git -c commit.gpgsign=false commit -qam "F1 feature change"
+        git push -q origin feature/linear
+    )
+}
+
+add_merge_commit_on_feature() {
+    # Add a merge commit onto the feature branch to trigger the linearity failure.
+    (
+        cd "$UPSTREAM"
+        git checkout -q -b other main
+        echo other > other.txt
+        git add other.txt
+        git -c commit.gpgsign=false commit -q -m "other branch commit"
+
+        git checkout -q feature/linear
+        git -c commit.gpgsign=false merge -q --no-ff other -m "Merge other into feature"
+        git push -q origin feature/linear
+    )
+}
+
+shallow_clone_like_actions_checkout() {
+    # Reproduce actions/checkout@v6 default: a real shallow clone (depth=1)
+    # with a narrow refspec pointing at the PR branch. file:// is required —
+    # local path clones silently ignore --depth.
+    CI_REPO="$WORKDIR/ci"
+    git clone -q --depth=1 --branch feature/linear "file://$ORIGIN" "$CI_REPO"
+}
+
+expect_exit() {
+    want=$1; shift
+    name=$1; shift
+    set +e
+    output=$("$@" 2>&1)
+    got=$?
+    set -e
+    if [ "$got" -eq "$want" ]; then
+        pass=$((pass + 1))
+        echo "PASS  $name"
+    else
+        fail=$((fail + 1))
+        echo "FAIL  $name: want exit $want, got $got"
+        echo "----- output -----"
+        echo "$output"
+        echo "------------------"
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Test 1: linear branch in a shallow CI clone with GITHUB_HEAD_REF should pass
+# --------------------------------------------------------------------------
+setup_origin_with_linear_branch
+shallow_clone_like_actions_checkout
+
+expect_exit 0 "shallow+GITHUB_HEAD_REF, linear branch" \
+    env -C "$CI_REPO" GITHUB_HEAD_REF=feature/linear "$HOOK" main
+
+rm -rf "$WORKDIR"
+
+# --------------------------------------------------------------------------
+# Test 2: branch with a merge commit in shallow CI clone should fail
+# --------------------------------------------------------------------------
+setup_origin_with_linear_branch
+add_merge_commit_on_feature
+shallow_clone_like_actions_checkout
+
+expect_exit 1 "shallow+GITHUB_HEAD_REF, branch has merge commit" \
+    env -C "$CI_REPO" GITHUB_HEAD_REF=feature/linear "$HOOK" main
+
+rm -rf "$WORKDIR"
+
+# --------------------------------------------------------------------------
+# Test 3: no GITHUB_HEAD_REF (local run), linear branch, should pass
+# --------------------------------------------------------------------------
+setup_origin_with_linear_branch
+LOCAL_REPO="$WORKDIR/local"
+git clone -q --branch feature/linear "$ORIGIN" "$LOCAL_REPO"
+
+expect_exit 0 "local (no GITHUB_HEAD_REF), linear branch" \
+    env -C "$LOCAL_REPO" -u GITHUB_HEAD_REF "$HOOK" main
+
+rm -rf "$WORKDIR"
+
+# --------------------------------------------------------------------------
+# Test 4: no GITHUB_HEAD_REF (local run), branch with merge commit, should fail
+# --------------------------------------------------------------------------
+setup_origin_with_linear_branch
+add_merge_commit_on_feature
+LOCAL_REPO="$WORKDIR/local"
+git clone -q --branch feature/linear "$ORIGIN" "$LOCAL_REPO"
+
+expect_exit 1 "local (no GITHUB_HEAD_REF), branch has merge commit" \
+    env -C "$LOCAL_REPO" -u GITHUB_HEAD_REF "$HOOK" main
+
+rm -rf "$WORKDIR"
+
+unset WORKDIR


### PR DESCRIPTION
## Summary

`check-branch-linearity` v0.57.0 crashes with `exit 128` on PRs in GitHub Actions as soon as `actions/checkout` is left at its default depth (1). Reported by @tmaurin in [this thread](https://kpler.slack.com/archives/C0ARLLA64H3/p1777034143927169).

Two bugs combined:

1. **`--shallow-exclude=<SHA>` is not supported.** The option is forwarded to the server as `deepen-not <value>` and the remote `upload-pack` rejects anything that isn't a ref:
   ```
   fatal: git upload-pack: deepen-not is not a ref: deepen-not <sha>
   ```
   `2> /dev/null` hid this error from the user.

2. **`origin/$GITHUB_HEAD_REF` assumes a full refspec.** `actions/checkout` (and plain `git clone --depth=1`) configure a narrow refspec that only maps the checked-out branch into `refs/remotes/origin/*`, so a subsequent `git fetch origin $GITHUB_HEAD_REF` only lands in `FETCH_HEAD`. `git rev-parse origin/$GITHUB_HEAD_REF` then explodes:
   ```
   fatal: ambiguous argument 'origin/story/...': unknown revision
   ```

## Fix

- Pass `$TARGET_BRANCH` (ref name) to `--shallow-exclude`
- Read both `target_sha` and `tip` from `FETCH_HEAD` — refspec-agnostic
- Drop `2> /dev/null` so real fetch failures surface
- Fall back to a plain fetch if `shallow-exclude` is unsupported by the remote

## Test plan

- [x] New `tests/test_git_branch_linearity.sh` with 4 scenarios: shallow+PR (linear / with merge commit) and local (linear / with merge commit). Verified the suite **fails** against v0.57.0 and **passes** against the fix.
- [x] Added `.github/workflows/test.yml`:
  - `git-branch-linearity` job runs the test suite
  - `git-branch-linearity-self` job runs the hook against the PR branch under `actions/checkout@v6` defaults — the exact setup that broke in v0.57.0
- [x] CI green on this PR
- [x] **End-to-end validation in the real repo that was broken.** Reproduced @tmaurin's failing state in `supply-demand-lng` (PR #122, SHA `2778d4937c...`) with a single change — `rev: v0.57.0` → this PR's fix commit — then ran the same CI pipeline in two configurations:

  | Configuration | `actions/checkout` | Result |
  |---|---|---|
  | Shallow clone (default) | `fetch-depth: 1` | ✅ `Check for git branch linearity... Passed` ([job](https://github.com/Kpler/supply-demand-lng/actions/runs/24891446129/job/72884568583)) |
  | Full clone | `fetch-depth: 0` | ✅ `Check for git branch linearity... Passed` ([job](https://github.com/Kpler/supply-demand-lng/actions/runs/24892914858/job/72889755456)) |

  Validation PR (now closed): Kpler/supply-demand-lng#123.

## Workaround for users until merged

Pin `kp-pre-commit-hooks` to `v0.56.0`.