### PR TITLE
fix: avoid shallow-ifying full local clones

### DIFF
--- a/git-branch-linearity.sh
+++ b/git-branch-linearity.sh
@@ -4,7 +4,18 @@
 TARGET_BRANCH="${1:-main}"
 
 echo "Target branch: $TARGET_BRANCH"
-git fetch --no-tags --depth=1 origin "$TARGET_BRANCH"
+
+# Only fetch shallowly if the clone is already shallow. On a full local clone
+# (typical dev setup), `--depth=1` would truncate origin/$TARGET_BRANCH to a
+# single commit and write a `.git/shallow` file, leaving the developer's main
+# detached from prior history.
+if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+    fetch_depth="--depth=1"
+else
+    fetch_depth=""
+fi
+
+git fetch --no-tags $fetch_depth origin "$TARGET_BRANCH"
 target_sha=$(git rev-parse FETCH_HEAD)
 
 # If in a github PR, base from tip of branch, not the merge commit.

--- a/tests/test_git_branch_linearity.sh
+++ b/tests/test_git_branch_linearity.sh
@@ -38,8 +38,10 @@ trap on_exit EXIT
 
 setup_origin_with_linear_branch() {
     # Build an "origin" bare repo with:
-    #   - main at commit M1
-    #   - feature branched from M1, with one additional linear commit F1
+    #   - main at commit M3 (three commits: M1, M2, M3)
+    #   - feature branched from M3, with one additional linear commit F1
+    # main has multiple commits so shallow-ification (truncation to 1 commit)
+    # is observable in tests that inspect origin/main history afterwards.
     WORKDIR=$(mktemp -d)
     ORIGIN="$WORKDIR/origin.git"
     UPSTREAM="$WORKDIR/upstream"
@@ -55,6 +57,10 @@ setup_origin_with_linear_branch() {
         echo initial > file.txt
         git add file.txt
         git -c commit.gpgsign=false commit -q -m "M1 initial"
+        echo two >> file.txt
+        git -c commit.gpgsign=false commit -qam "M2"
+        echo three >> file.txt
+        git -c commit.gpgsign=false commit -qam "M3"
         git push -q origin main
 
         git checkout -q -b feature/linear
@@ -106,6 +112,29 @@ expect_exit() {
     fi
 }
 
+expect_not_shallow() {
+    name=$1; repo=$2
+    if [ -f "$repo/.git/shallow" ]; then
+        fail=$((fail + 1))
+        echo "FAIL  $name: .git/shallow exists, repo was unexpectedly shallow-ified"
+    else
+        pass=$((pass + 1))
+        echo "PASS  $name"
+    fi
+}
+
+expect_full_main_history() {
+    name=$1; repo=$2; want_count=$3
+    got=$(git -C "$repo" rev-list --count origin/main)
+    if [ "$got" -eq "$want_count" ]; then
+        pass=$((pass + 1))
+        echo "PASS  $name"
+    else
+        fail=$((fail + 1))
+        echo "FAIL  $name: origin/main has $got commits, expected $want_count"
+    fi
+}
+
 # --------------------------------------------------------------------------
 # Test 1: linear branch in a shallow CI clone with GITHUB_HEAD_REF should pass
 # --------------------------------------------------------------------------
@@ -151,6 +180,25 @@ git clone -q --branch feature/linear "$ORIGIN" "$LOCAL_REPO"
 
 expect_exit 1 "local (no GITHUB_HEAD_REF), branch has merge commit" \
     env -C "$LOCAL_REPO" -u GITHUB_HEAD_REF "$HOOK" main
+
+rm -rf "$WORKDIR"
+
+# --------------------------------------------------------------------------
+# Test 5: local full clone must not be shallow-ified by the hook.
+#
+# Regression test for the v0.57.0/v0.58.0 bug where the unconditional
+# `git fetch --depth=1 origin main` truncated origin/main to a single commit
+# on full clones, leaving the developer's local main detached from prior
+# history. Reported by @tmaurin in the Slack thread that triggered PR 73.
+# --------------------------------------------------------------------------
+setup_origin_with_linear_branch
+LOCAL_REPO="$WORKDIR/local"
+git clone -q --branch feature/linear "$ORIGIN" "$LOCAL_REPO"
+
+env -C "$LOCAL_REPO" -u GITHUB_HEAD_REF "$HOOK" main > /dev/null 2>&1
+
+expect_not_shallow "local full clone stays non-shallow after hook run" "$LOCAL_REPO"
+expect_full_main_history "local origin/main keeps full history (3 commits)" "$LOCAL_REPO" 3
 
 rm -rf "$WORKDIR"
 


### PR DESCRIPTION
## Summary

Follow-up to #73. v0.58.0's `git fetch --no-tags --depth=1 origin $TARGET_BRANCH` runs unconditionally from the `pre-push` hook. On a **full local clone** (the typical dev setup), `--depth=1` writes a `.git/shallow` file and truncates `origin/$TARGET_BRANCH` to a single commit, leaving the developer's local `main` detached from prior history. After a `git push`, users see weird states — rebases produce unexpected conflicts because the ancestor commits previously visible under `origin/main` have disappeared.

Reported by @tmaurin in [the same Slack thread](https://kpler.slack.com/archives/C0ARLLA64H3/p1777034143927169) that triggered #73 (recovery: `git fetch --unshallow`). @dhalmschlager correctly diagnosed the mechanism and suggested the guard.

## Reproduction (5 lines of shell on a full clone)

```sh
git clone <remote> /tmp/test && cd /tmp/test
test -f .git/shallow && echo "shallow BEFORE" || echo "not shallow BEFORE"
git fetch --no-tags --depth=1 origin main   # what v0.58.0 runs
test -f .git/shallow && echo "shallow AFTER" || echo "not shallow AFTER"
git log origin/main --oneline | wc -l       # now 1 instead of full history
```

## Fix

Gate `--depth=1` on whether the clone is already shallow:

```sh
if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
    fetch_depth="--depth=1"
else
    fetch_depth=""
fi
git fetch --no-tags $fetch_depth origin "$TARGET_BRANCH"
```

CI (starts shallow via `actions/checkout@v6` defaults) keeps the fast `--depth=1` path; local full clones fetch normally and preserve their history.

## Test plan

- [x] New regression test in `tests/test_git_branch_linearity.sh`: runs the hook on a full local clone and asserts both that `.git/shallow` is absent and that `origin/main` retains its full 3-commit history.
- [x] Confirmed the new test **fails** against v0.58.0 (`origin/main has 1 commits, expected 3`) and **passes** with this fix.
- [x] Existing 4 tests from #73 still pass (6/6 total).
- [x] **Local validation on the real `supply-demand-lng` repo** at the commit that originally failed (SHA `2778d4937c`):

  | Scenario | `.git/shallow` after hook | `origin/main` commits after hook |
  |---|---|---|
  | Full clone + v0.58.0 (current) | ❌ created | 278 → **1** (bug reproduced) |
  | Full clone + this fix | ✅ absent | 278 → **278** (preserved) |
  | Shallow clone + this fix + `GITHUB_HEAD_REF` | ✅ stays shallow | exit 0 |

- [x] **End-to-end CI validation in the real repo that was broken**. Reopened the failing state of PR #122 (SHA `2778d4937c`) with a single change — `rev: v0.57.0` → this PR's fix commit — then ran the pre-commit workflow in **both** `actions/checkout` configurations:

  | Configuration | `actions/checkout` | Result |
  |---|---|---|
  | Shallow clone (default) | `fetch-depth: 1` | ✅ `Check for git branch linearity... Passed` ([job](https://github.com/Kpler/supply-demand-lng/actions/runs/24908130293/job/72942646047)) |
  | Full clone | `fetch-depth: 0` | ✅ `Check for git branch linearity... Passed` ([job](https://github.com/Kpler/supply-demand-lng/actions/runs/24908327342/job/72943316965)) |

  Validation PRs (now closed): Kpler/supply-demand-lng#124 (shallow) and Kpler/supply-demand-lng#125 (full).