### PR TITLE
chore(deps): add 7-day Dependabot cooldown (PTFM-18885) [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    cooldown: # Reduce supply chain attack risk
+      default-days: 7


### PR DESCRIPTION
## Summary
Adds `cooldown: { default-days: 7 }` to every `package-ecosystem` block in `.github/dependabot.yml`.

## Why
Mitigates supply-chain attacks where a malicious version is published, detected, and yanked within hours/days — without cooldown, Dependabot can open a PR for the malicious version before it is pulled.

## Jira
[PTFM-18885](https://kpler.atlassian.net/browse/PTFM-18885)

[PTFM-18885]: https://kpler.atlassian.net/browse/PTFM-18885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ