### PR TITLE
perf: disk-cache JSON schemas for gitops-values-validation

### DIFF
--- a/kp_pre_commit_hooks/gitops_values_validation.py
+++ b/kp_pre_commit_hooks/gitops_values_validation.py
@@ -1,3 +1,4 @@
+import json
 import re
 import sys
 import textwrap
@@ -142,16 +143,33 @@ class SchemaValidationError(Exception):
     hint: Optional[str] = None
 
 
+SCHEMA_CACHE_DIR = Path.home() / ".cache" / "pre-commit" / "kp-pre-commit-hooks" / "schemas"
+
+
 @cache
 def download_json_schema(url: str) -> dict:
-    """Download and cache JSON schema from URL"""
+    """Download JSON schema, using a persistent disk cache for versioned URLs."""
+    filename = url.removeprefix(SCHEMA_BASE_URL + "/").replace("/", "_")
+    cache_file = SCHEMA_CACHE_DIR / filename
+
+    if cache_file.exists():
+        try:
+            return json.loads(cache_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            warnings.warn(f"Corrupted schema cache file {cache_file}, re-downloading")
+            cache_file.unlink(missing_ok=True)
+
     response = requests.get(url, timeout=10, verify=True)
     if response.status_code == 403:
         raise UnauthorizedToDownloadSchema(url)
     if response.status_code == 404:
         raise MissingSchema(url)
     response.raise_for_status()
-    return response.json()
+
+    schema = response.json()
+    SCHEMA_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(json.dumps(schema))
+    return schema
 
 # Registry for resolving schema references
 SCHEMA_REGISTRY = REGISTRY.combine(


### PR DESCRIPTION
## Summary

- Cache downloaded JSON schemas to disk at `~/.cache/pre-commit/kp-pre-commit-hooks/schemas/`
- Schema URLs are versioned and immutable, so the cache never goes stale
- Saves ~30s per run (measured from Singapore from atm-gitops)
- First run still downloads from S3, subsequent runs read from local disk

The cache is inside `~/.cache/pre-commit` so a ` pre-commit clean` will also delete it.
the cache is "global" so even if mutiple version of the hooks are used in different gitops repo schema will be dl only once 


## Tests

From a repo that uses the `gitops-values-validation` hook:

```bash
# Clear any existing cache
rm -rf ~/.cache/pre-commit/kp-pre-commit-hooks/schemas/

# First run (populates cache)
time pre-commit try-repo ../kp-pre-commit-hooks/ gitops-values-validation --verbose --all-files

# Second run
time pre-commit try-repo ../kp-pre-commit-hooks/ gitops-values-validation --verbose --all-files
```

Tested on atm-gitops (using 4 version of the platform chart) from SG it about 30s faster