### PR TITLE
chore(ci): add Dependabot cooldown for pre-commit hooks (PTFM-24090) [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown:
+    cooldown: # Reduce supply chain attacks risk
       default-days: 7
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
       interval: "weekly"
     cooldown: # Reduce supply chain attack risk
       default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
@@ -8,7 +8,7 @@ repos:
         stages: [commit]
     -   id: trailing-whitespace
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+    rev: a30f0d816e5062a67d87c8de753cfe499672b959 # v1.5.5
     hooks:
     -   id: forbid-crlf
     -   id: remove-crlf


### PR DESCRIPTION
## Summary

Adds `package-ecosystem: "pre-commit"` with `cooldown: default-days: 7` to `.github/dependabot.yml`.

## Why

Without a cooldown, Dependabot opens PRs for pre-commit hook updates immediately on release. A 7-day minimum age gives time for hooks to stabilise and reduces noise from yanked or broken releases.

## Jira
[PTFM-24090](https://kpler.atlassian.net/browse/PTFM-24090)


[PTFM-24090]: https://kpler.atlassian.net/browse/PTFM-24090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ