### PR TITLE
chore: ignore archibot-db-gateway httpGet.port schema errors

### DIFF
--- a/kp_pre_commit_hooks/gitops_values_validation.py
+++ b/kp_pre_commit_hooks/gitops_values_validation.py
@@ -464,7 +464,19 @@ class ServiceInstanceConfigValidator:
             "$.platform-managed-chart.api.deployment": [
                 "Additional properties are not allowed ('tolerations' was unexpected)"
             ]
-        }
+        },
+        # Chart templates honor httpGet.port (default image.port), but the strict
+        # values schema only allows path. Whitelist until platform-managed-chart
+        # schema accepts port (needed for archibot-db-gateway :8080 /healthz while
+        # image.port stays on TLS :8443).
+        "archibot": {
+            "$.platform-managed-chart.services['archibot-db-gateway'].livenessProbe.httpGet": [
+                "Additional properties are not allowed ('port' was unexpected)"
+            ],
+            "$.platform-managed-chart.services['archibot-db-gateway'].readinessProbe.httpGet": [
+                "Additional properties are not allowed ('port' was unexpected)"
+            ],
+        },
     }
 
     def __init__(self, service_instance_config: ServiceInstanceConfig):

--- a/kp_pre_commit_hooks/gitops_values_validation.py
+++ b/kp_pre_commit_hooks/gitops_values_validation.py
@@ -465,10 +465,6 @@ class ServiceInstanceConfigValidator:
                 "Additional properties are not allowed ('tolerations' was unexpected)"
             ]
         },
-        # Chart templates honor httpGet.port (default image.port), but the strict
-        # values schema only allows path. Whitelist until platform-managed-chart
-        # schema accepts port (needed for archibot-db-gateway :8080 /healthz while
-        # image.port stays on TLS :8443).
         "archibot": {
             "$.platform-managed-chart.services['archibot-db-gateway'].livenessProbe.httpGet": [
                 "Additional properties are not allowed ('port' was unexpected)"


### PR DESCRIPTION
## Summary
- Whitelist `archibot` `archibot-db-gateway` liveness/readiness `httpGet.port` validation errors in `IGNORED_VALIDATION_ERRORS`.
- Needed so gitops can health-check the plain-HTTP `:8080` `/healthz` listener while `image.port` remains TLS `:8443`.
