### PR TITLE
fix: match archibot httpGet.port ignore keys to jsonschema 4.19 json_path

### DIFF
--- a/kp_pre_commit_hooks/gitops_values_validation.py
+++ b/kp_pre_commit_hooks/gitops_values_validation.py
@@ -465,11 +465,12 @@ class ServiceInstanceConfigValidator:
                 "Additional properties are not allowed ('tolerations' was unexpected)"
             ]
         },
+        # jsonschema 4.19.0 emits hyphenated keys with dot notation (not brackets).
         "archibot": {
-            "$.platform-managed-chart.services['archibot-db-gateway'].livenessProbe.httpGet": [
+            "$.platform-managed-chart.services.archibot-db-gateway.livenessProbe.httpGet": [
                 "Additional properties are not allowed ('port' was unexpected)"
             ],
-            "$.platform-managed-chart.services['archibot-db-gateway'].readinessProbe.httpGet": [
+            "$.platform-managed-chart.services.archibot-db-gateway.readinessProbe.httpGet": [
                 "Additional properties are not allowed ('port' was unexpected)"
             ],
         },


### PR DESCRIPTION
## Summary
- Fix `IGNORED_VALIDATION_ERRORS` keys for `archibot` / `archibot-db-gateway` `httpGet.port` to use **dot notation** (`services.archibot-db-gateway`), matching `error.json_path` from `jsonschema==4.19.0` (the version pinned in the hook).
- The v0.61.0 ignore used bracket notation (`services['archibot-db-gateway']`), so it never matched and CI still failed on `values-dev-tech-support.yaml`.

Follow-up to #83. Unblocks [cloud-platform-gitops#413](https://github.com/Kpler/cloud-platform-gitops/pull/413).

## Test plan
- [ ] Confirm with `jsonschema==4.19.0` that `error.json_path` is `$.platform-managed-chart.services.archibot-db-gateway.livenessProbe.httpGet` (and readiness equivalent).
- [ ] After release/tag + bump `rev` in `cloud-platform-gitops` `.pre-commit-config.yaml`, re-run PR 413 pre-commit and confirm `tech-support instance dev` passes with `httpGet.port: 8080`.


Made with [Cursor](https://cursor.com)