### PR TITLE
feat: mirror kp-pre-commit-hooks to maritimeais GHES on push to main

### DIFF
--- a/.github/workflows/mirror-to-ghes.yml
+++ b/.github/workflows/mirror-to-ghes.yml
@@ -1,0 +1,63 @@
+# mirror-to-ghes.yml
+#
+# Mirrors this repository (github.com/Kpler/kp-pre-commit-hooks) to the Maritime
+# AIS GitHub Enterprise Server instance on every push to main.
+#
+# Authentication uses a GitHub App installed on the GHES instance — no PAT.
+# A short-lived installation token is generated at runtime and used as the
+# remote credential, so no long-lived secret is embedded anywhere.
+#
+# Required repository secrets:
+#   GHES_APP_ID          – GitHub App ID (numeric)
+#   GHES_APP_PRIVATE_KEY – GitHub App private key (PEM format)
+
+name: mirror-to-ghes
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  GHES_HOST: maritimeais.ghe.com
+  GHES_API_URL: https://maritimeais.ghe.com/api/v3
+  GHES_ORG: mais
+  GHES_REPO: kp-pre-commit-hooks
+
+# Prevent concurrent mirror pushes from racing or corrupting history.
+concurrency:
+  group: mirror-to-ghes
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: Mirror to GHES
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Generate GHES App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GHES_APP_ID }}
+          private-key: ${{ secrets.GHES_APP_PRIVATE_KEY }}
+          owner: ${{ env.GHES_ORG }}
+          github-api-url: ${{ env.GHES_API_URL }}
+
+      # Bare clone so all refs land under refs/heads/* and refs/tags/* rather
+      # than refs/remotes/origin/*. git push --mirror then syncs every branch
+      # and tag correctly without manual ref translation.
+      - name: Bare-clone source and push mirror to GHES
+        run: |
+          git clone --bare \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            bare-repo
+          cd bare-repo
+          git push --mirror \
+            "https://x-access-token:${APP_TOKEN}@${GHES_HOST}/${GHES_ORG}/${GHES_REPO}.git"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/mirror-to-ghes.yml` that pushes a full git mirror of this repo to `maritimeais.ghe.com/mais/kp-pre-commit-hooks` on every push to `main` (plus manual `workflow_dispatch`). This makes the pre-commit hooks resolvable from repos on the `mais` GHES instance (needed by the cookiecutter-python `maritimeais` target, which references `https://maritimeais.ghe.com/mais/kp-pre-commit-hooks`).

Same approach as [Kpler/github-actions#587](https://github.com/Kpler/github-actions/pull/587):
- Short-lived **GitHub App installation token** — no PAT, no long-lived credential.
- `git clone --bare` + `git push --mirror` so every branch and tag syncs faithfully (tag refs matter here: pre-commit pins `rev:` to tags like `v0.60.0`).
- Instance-specific values (host, API URL, org, repo) are `env` vars at the top.
- Concurrency group (`cancel-in-progress: false`) serializes runs so no push is dropped.

## Pre-requisites — one-time manual setup

### 1. Create the target repo on the GHES  ⚠️ (does not exist yet)
`git push --mirror` requires the destination to exist. On `https://maritimeais.ghe.com`, create an **empty** repo `mais/kp-pre-commit-hooks` (no README/gitignore/license — it must be empty so the mirror push isn't rejected). Match visibility to `mais/github-actions` (internal).

### 2. GitHub App on the GHES instance
You can **reuse the existing App** created for `github-actions` (e.g. `github-actions-mirror`) — it only needs **Contents: Read & write**. Either:
- **Reuse:** in the App's **Install App** settings, make sure its installation on the `mais` org includes `kp-pre-commit-hooks` (either "All repositories" or add this repo to the selected list). Reuse the same App ID + private key for the secrets below.
- **Or create a new App** following the same steps as github-actions#587 (Settings → Developer settings → GitHub Apps → New; Contents: Read & write; install on `mais`; note App ID; generate a `.pem`).

### 3. Add secrets to `github.com/Kpler/kp-pre-commit-hooks`
**Settings → Secrets and variables → Actions**:

| Secret | Value |
|---|---|
| `GHES_APP_ID` | Numeric App ID |
| `GHES_APP_PRIVATE_KEY` | Full contents of the App's `.pem` private key |

### 4. Grant enterprise Actions access on the mirror (if hooks are consumed as actions)
Not required for plain pre-commit `repo:` clones (runners just read-clone it). Only needed if some repo `uses:` a workflow/action from `mais/kp-pre-commit-hooks`:
`GH_HOST=maritimeais.ghe.com gh api --method PUT /repos/mais/kp-pre-commit-hooks/actions/permissions/access -f access_level=enterprise`

## Test plan
- [ ] Complete pre-requisites 1–3 before merging
- [ ] Merge to `main` → `mirror-to-ghes` triggers automatically
- [ ] Actions tab: `mirror-to-ghes` run is green
- [ ] `https://maritimeais.ghe.com/mais/kp-pre-commit-hooks` history matches github.com (same SHAs, all branches **and tags** present)
- [ ] Follow-up commit to `main` updates the GHES mirror within seconds
- [ ] Actions → mirror-to-ghes → Run workflow performs a manual re-sync successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)